### PR TITLE
fix: Added support for runtiveConfig from envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,12 @@ config property `yandexMetrika`.
 - Description: Yandex metrika ID
 
 Other parameters you can see in the type file [here](src/runtime/type.ts)
+
+## Runtime Config
+
+Alternatively, leveraging [automatically replaced public runtime config values](https://nuxt.com/docs/api/configuration/nuxt-config#runtimeconfig) by matching environment variables at runtime, set your desired option in your project's `.env` file:
+
+```bash
+# Sets the `yandexMetrika.id` module option
+NUXT_PUBLIC_YANDEX_METRIKA_ID=12345678
+```

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,6 +3,13 @@ import MyModule from '../'
 
 export default defineNuxtConfig({
   modules: [MyModule],
+  runtimeConfig: {
+    public: {
+      yandexMetrika: {
+        id: '', // NUXT_PUBLIC_YANDEX_METRIKA_ID
+      },
+    },
+  },
   yandexMetrika: {
     id: '49439650',
   },

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -3,13 +3,6 @@ import MyModule from '../'
 
 export default defineNuxtConfig({
   modules: [MyModule],
-  runtimeConfig: {
-    public: {
-      yandexMetrika: {
-        id: '', // NUXT_PUBLIC_YANDEX_METRIKA_ID
-      },
-    },
-  },
   yandexMetrika: {
     id: '49439650',
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import { defu } from 'defu'
-import { addPlugin, createResolver, defineNuxtModule, logger } from '@nuxt/kit'
+import { addPlugin, createResolver, defineNuxtModule } from '@nuxt/kit'
 import type { NuxtModule } from 'nuxt/schema'
 import { name, version } from '../package.json'
 import type { MetrikaModuleParams } from './runtime/type'
@@ -45,52 +45,14 @@ const module: NuxtModule<Omit<MetrikaModuleParams, 'id'>> = defineNuxtModule<Omi
     const resolver = createResolver(import.meta.url)
     nuxt.options.build.transpile.push(resolver.resolve('./runtime'))
 
-    if (!nuxt.options.dev && ['production', 'test'].includes(process.env.NODE_ENV!)) {
-      if (!isValid(moduleOptions)) {
-        logger.info('[yandex.metrika] module cannot be initialized, please specify ID')
-        return
-      }
+    addPlugin({ src: resolve(__dirname, './runtime/serverPlugin'), mode: 'server' })
 
-      // setting up script tag
-      nuxt.options.app.head.script = nuxt.options.app.head.script || []
-      nuxt.options.app.head.script.unshift({
-        id: 'metrika',
-        innerHTML: getScriptTag(moduleOptions),
-      })
-
-      // setting up no-script tag
-      nuxt.options.app.head.noscript = nuxt.options.app.head.noscript || []
-      nuxt.options.app.head.noscript.unshift({
-        innerHTML: getNoscript(moduleOptions.id),
-      })
-
+    if (!nuxt.options.dev && ['production', 'test'].includes(process.env.NODE_ENV!))
       addPlugin({ src: resolve(__dirname, './runtime/plugin'), mode: 'client' })
-    }
-    else if (options.verbose === true) {
+
+    else if (options.verbose === true)
       addPlugin({ src: resolve(__dirname, './runtime/plugin-dev'), mode: 'client' })
-    }
   },
 })
-
-function isValid(options: Partial<MetrikaModuleParams>): options is MetrikaModuleParams {
-  return !!options.id
-}
-
-function getScriptTag(options: MetrikaModuleParams) {
-  const libURL = !options.useCDN ? 'https://mc.yandex.ru/metrika/tag.js' : 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js'
-  const metrikaContent = `
-    (function(m,e,t,r,i,k,a){
-    m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-    m[i].l=1*new Date();
-    k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-    (window, document, "script", "${libURL}", "ym");
-    ym("${options.id}", "init", ${JSON.stringify(options.initParams)});
-  `
-  return metrikaContent.trim()
-}
-
-function getNoscript(id: string) {
-  return `<div><img src="https://mc.yandex.ru/watch/${id}" style="position:absolute; left:-9999px;" alt="" /></div>`
-}
 
 export default module

--- a/src/runtime/serverPlugin.ts
+++ b/src/runtime/serverPlugin.ts
@@ -1,0 +1,49 @@
+import type { MetaObject } from '@nuxt/schema'
+import type { MetrikaModuleParams } from '../runtime/type'
+import { defineNuxtPlugin, useHead, useRuntimeConfig } from '#app'
+
+export default defineNuxtPlugin(() => {
+  const moduleOptions = useRuntimeConfig().public.yandexMetrika
+  if (!isValid(moduleOptions)) {
+    // eslint-disable-next-line no-console
+    console.log('[yandex.metrika] module cannot be initialized, please specify ID')
+    return
+  }
+
+  const meta: MetaObject = {}
+  // setting up script tag
+  meta.script = meta.script || []
+  meta.script.unshift({
+    id: 'metrika',
+    innerHTML: getScriptTag(moduleOptions),
+  })
+
+  // setting up no-script tag
+  meta.noscript = meta.noscript || []
+  meta.noscript.unshift({
+    innerHTML: getNoscript(moduleOptions.id),
+  })
+
+  useHead(meta)
+})
+
+function isValid(options: Partial<MetrikaModuleParams>): options is MetrikaModuleParams {
+  return !!options.id
+}
+
+function getScriptTag(options: MetrikaModuleParams) {
+  const libURL = !options.useCDN ? 'https://mc.yandex.ru/metrika/tag.js' : 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js'
+  const metrikaContent = `
+    (function(m,e,t,r,i,k,a){
+    m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
+    m[i].l=1*new Date();
+    k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
+    (window, document, "script", "${libURL}", "ym");
+    ym("${options.id}", "init", ${JSON.stringify(options.initParams)});
+  `
+  return metrikaContent.trim()
+}
+
+function getNoscript(id: string) {
+  return `<div><img src="https://mc.yandex.ru/watch/${id}" style="position:absolute; left:-9999px;" alt="" /></div>`
+}

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -38,17 +38,19 @@ describe('module tests', async () => {
     await page.waitForEvent('console')
     await page.waitForEvent('console')
     await page.waitForEvent('console')
+    await page.waitForEvent('console')
 
     expect(logs).toContain(`PageView. Counter 49439650. URL: ${url || ''}/?_ym_debug=1. Referrer: `)
+    expect(logs).toContain('Form goal. Counter 49439650. Init.')
     expect(logs).toContain('PageView. Counter 49439650. URL: /?_ym_debug=1. Referrer: ')
     expect(logs).toContain('Reach goal. Counter: 49439650. Goal id: zzz')
 
     await page.click('#a')
     await page.waitForEvent('console')
-    expect(logs[3]).toEqual('PageView. Counter 49439650. URL: /a. Referrer: /?_ym_debug=1')
+    expect(logs[4]).toEqual('PageView. Counter 49439650. URL: /a. Referrer: /?_ym_debug=1')
 
     await page.click('#b')
     await page.waitForEvent('console')
-    expect(logs[4]).toEqual('PageView. Counter 49439650. URL: /b. Referrer: /a')
+    expect(logs[5]).toEqual('PageView. Counter 49439650. URL: /b. Referrer: /a')
   }, { timeout: 15000 })
 })


### PR DESCRIPTION
Added support for NUXT_PUBLIC_YANDEX_METRIKA_ID usage
Moved part of code to server plugin, because runtime config in module not already parsed environment variables from

Motivation:
For different environment need to use different id's or options without changing code

How to reproduce:
- Remove metrika id from root config
- run `npm run dev:build`
- run `NUXT_PUBLIC_YANDEX_METRIKA_ID=49439650 npm run dev:start`