### PR TITLE
fix: Fix initialize for non ssr mode, remove plugin in dev mode

### DIFF
--- a/src/runtime/serverPlugin.ts
+++ b/src/runtime/serverPlugin.ts
@@ -14,7 +14,7 @@ export default defineNuxtPlugin(() => {
   // setting up script tag
   meta.script = meta.script || []
   meta.script.unshift({
-    id: 'metrika',
+    id: 'metrika-init',
     innerHTML: getScriptTag(moduleOptions),
   })
 
@@ -32,13 +32,7 @@ function isValid(options: Partial<MetrikaModuleParams>): options is MetrikaModul
 }
 
 function getScriptTag(options: MetrikaModuleParams) {
-  const libURL = !options.useCDN ? 'https://mc.yandex.ru/metrika/tag.js' : 'https://cdn.jsdelivr.net/npm/yandex-metrica-watch/tag.js'
   const metrikaContent = `
-    (function(m,e,t,r,i,k,a){
-    m[i]=m[i]||function(){(m[i].a=m[i].a||[]).push(arguments)};
-    m[i].l=1*new Date();
-    k=e.createElement(t),a=e.getElementsByTagName(t)[0],k.async=1,k.src=r,a.parentNode.insertBefore(k,a)})
-    (window, document, "script", "${libURL}", "ym");
     ym("${options.id}", "init", ${JSON.stringify(options.initParams)});
   `
   return metrikaContent.trim()

--- a/test/dev.test.ts
+++ b/test/dev.test.ts
@@ -1,0 +1,32 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+describe('development mode tests', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    browser: true,
+    dev: true, // This part is tested
+    nuxtConfig: {
+      yandexMetrika: {
+        id: '49439650',
+        noscript: true,
+        initParams: {
+          defer: false,
+          clickmap: false,
+          trackLinks: true,
+          accurateTrackBounce: false,
+          webvisor: false,
+          ecommerce: false,
+        },
+      },
+    },
+  })
+
+  it('script tag not injected in dev mode', async () => {
+    // TODO
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const page = await $fetch('/')
+    expect(page).not.toContain('ym("49439650", "init",')
+  })
+})

--- a/test/non-ssr.test.ts
+++ b/test/non-ssr.test.ts
@@ -1,0 +1,60 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { createPage, setup, useTestContext } from '@nuxt/test-utils'
+
+describe('non-ssr mode tests', async () => {
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    browser: true,
+    nuxtConfig: {
+      ssr: false, // This part is tested
+      yandexMetrika: {
+        id: '49439650',
+        noscript: true,
+        initParams: {
+          defer: false,
+          clickmap: false,
+          trackLinks: true,
+          accurateTrackBounce: false,
+          webvisor: false,
+          ecommerce: false,
+        },
+      },
+    },
+  })
+
+  it('should register serverPlugin in client mode ', () => {
+    const { nuxt } = useTestContext()
+    const serverPluginIndex = nuxt?.options.plugins.findIndex((plugin) => {
+      if (typeof plugin !== 'string' && plugin.src.includes('serverPlugin') && plugin.mode === 'client')
+        return true
+      return false
+    })
+    expect(serverPluginIndex).toBeGreaterThan(-1)
+  })
+
+  it('goal is reached and page hit after navigation is worked in non srr mode', async () => {
+    const page = await createPage('/?_ym_debug=1')
+    const logs: string[] = []
+    const { url } = useTestContext()
+    page.on('console', msg => logs.push(msg.text()))
+
+    await page.waitForEvent('console')
+    await page.waitForEvent('console')
+    await page.waitForEvent('console')
+    await page.waitForEvent('console')
+
+    expect(logs).toContain(`PageView. Counter 49439650. URL: ${url || ''}/?_ym_debug=1. Referrer: `)
+    expect(logs).toContain('Form goal. Counter 49439650. Init.')
+    expect(logs).toContain('PageView. Counter 49439650. URL: /?_ym_debug=1. Referrer: ')
+    expect(logs).toContain('Reach goal. Counter: 49439650. Goal id: zzz')
+
+    await page.click('#a')
+    await page.waitForEvent('console')
+    expect(logs[4]).toEqual('PageView. Counter 49439650. URL: /a. Referrer: /?_ym_debug=1')
+
+    await page.click('#b')
+    await page.waitForEvent('console')
+    expect(logs[5]).toEqual('PageView. Counter 49439650. URL: /b. Referrer: /a')
+  }, { timeout: 15000 })
+})

--- a/test/runtime-config.test.ts
+++ b/test/runtime-config.test.ts
@@ -1,0 +1,38 @@
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { $fetch, setup } from '@nuxt/test-utils'
+
+describe('runtime config tests', async () => {
+  import.meta.env.NUXT_PUBLIC_YANDEX_METRIKA_ID = '49439650' // This part is tested
+  await setup({
+    rootDir: fileURLToPath(new URL('../playground', import.meta.url)),
+    browser: true,
+    nuxtConfig: {
+      runtimeConfig: {
+        public: {
+          yandexMetrika: {
+            id: '',
+          },
+        },
+      },
+      yandexMetrika: {
+        noscript: true,
+        initParams: {
+          defer: false,
+          clickmap: false,
+          trackLinks: true,
+          accurateTrackBounce: false,
+          webvisor: false,
+          ecommerce: false,
+        },
+      },
+    },
+  })
+
+  it('should get id from env in runtime', async () => {
+    // TODO
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const page = await $fetch('/')
+    expect(page).toContain('ym("49439650", "init", {"defer":false,"clickmap":false,"trackLinks":true,"accurateTrackBounce":false,"webvisor":false,"ecommerce":false});')
+  })
+})


### PR DESCRIPTION
Because of my last change if ssr mode disabled this plugin throw 500 error. I apologize.

How to reproduce:
- Download repo with v1.0.3
- In playground set `ssr:false`
- run `pnpm run dev:prepare`
- run `pnpm run dev:build`
- run `pnpm run dev:start`

On page will apear error:
<img width="1439" alt="screenshoot" src="https://github.com/artmizu/yandex-metrika-nuxt/assets/36310479/abc90c5a-a7c4-4640-84d3-d7e86b63a05c">

So I fix it in this PR by divide init script, and placeholder script which catch all events before y.metrika is available

Also in this PR:
- Fix inject in development (now it doesn't inject in development, like in v1.0.2)
- Added more tests for development mode, `ssr:false` mode and runtime config integration

